### PR TITLE
Fix two bugs in the vicky implementation

### DIFF
--- a/src/mame/foenixretro/tiny_vicky.cpp
+++ b/src/mame/foenixretro/tiny_vicky.cpp
@@ -296,7 +296,7 @@ void tiny_vicky_video_device::draw_text(uint32_t *row, uint8_t mcr, bool enable_
                     row[screen_x] = fg_color;
                     row[screen_x + 1] = fg_color;
                 }
-                else if (!overlay || (overlay_font && (bg_color == 0)))
+                else if (!overlay || (overlay_font && (bg_color_index != 0)))
                 {
                     row[screen_x] = bg_color;
                     row[screen_x + 1] = bg_color;
@@ -309,7 +309,7 @@ void tiny_vicky_video_device::draw_text(uint32_t *row, uint8_t mcr, bool enable_
                 {
                     row[screen_x] = fg_color;
                 }
-                else if (!overlay || (overlay_font && (bg_color != 0)))
+                else if (!overlay || (overlay_font && (bg_color_index != 0)))
                 {
                     row[screen_x] = bg_color;
                 }

--- a/src/mame/foenixretro/tiny_vicky.cpp
+++ b/src/mame/foenixretro/tiny_vicky.cpp
@@ -81,7 +81,7 @@ uint32_t tiny_vicky_video_device::screen_update(screen_device &screen, bitmap_rg
                 // Check the Sart of Line registers
                 uint8_t sol_reg = m_iopage0_ptr[0x1018];
                 // 12-bit line
-                uint16_t sol_line = m_iopage0_ptr[0x1018] + ((m_iopage0_ptr[0x101a] & 0xf) << 8);
+                uint16_t sol_line = m_iopage0_ptr[0x1019] + ((m_iopage0_ptr[0x101a] & 0xf) << 8);
                 uint32_t *row = topleft + y * 800;
                 if ((sol_reg & 1) != 0 && y == sol_line)
                 {


### PR DESCRIPTION
- Fixes a bug in the SOL line calculation: an incorrect register was being used for the SOL lo-byte
- Fixes a bug in text overlay: the RGB value was misinterpreted as the LUT index
- Fixes a bug clipping sprites on left end right edges, leading to artifacts