### PR TITLE
f256k: Add SST39VF040 flash emulation with NVRAM persistence

### DIFF
--- a/src/devices/machine/intelfsh.cpp
+++ b/src/devices/machine/intelfsh.cpp
@@ -120,6 +120,7 @@ DEFINE_DEVICE_TYPE(SST_39SF010,              sst_39sf010_device,              "s
 DEFINE_DEVICE_TYPE(SST_39SF020,              sst_39sf020_device,              "sst_39sf020",              "SST 39SF020 Flash")
 DEFINE_DEVICE_TYPE(SST_39SF040,              sst_39sf040_device,              "sst_39sf040",              "SST 39SF040 Flash")
 DEFINE_DEVICE_TYPE(SST_39VF020,              sst_39vf020_device,              "sst_39vf020",              "SST 39VF020 Flash")
+DEFINE_DEVICE_TYPE(SST_39VF040,              sst_39vf040_device,              "sst_39vf040",              "SST 39VF040 Flash")
 DEFINE_DEVICE_TYPE(SST_49LF020,              sst_49lf020_device,              "sst_49lf020",              "SST 49LF020 Flash")
 
 DEFINE_DEVICE_TYPE(SHARP_LH28F400,           sharp_lh28f400_device,           "sharp_lh28f400",           "Sharp LH28F400 Flash")
@@ -290,6 +291,9 @@ sst_39sf040_device::sst_39sf040_device(const machine_config &mconfig, const char
 
 sst_39vf020_device::sst_39vf020_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, SST_39VF020, tag, owner, clock, 0x40000, MFG_SST, 0xd6) { m_sector_is_4k = true; }
+
+sst_39vf040_device::sst_39vf040_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: intelfsh8_device(mconfig, SST_39VF040, tag, owner, clock, 0x80000, MFG_SST, 0xd7) { m_addrmask = 0x1fff; m_sector_is_4k = true; }
 
 sst_49lf020_device::sst_49lf020_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, SST_49LF020, tag, owner, clock, 0x40000, MFG_SST, 0x61) { m_sector_is_4k = true; }
@@ -853,7 +857,7 @@ void intelfsh_device::write_full(uint32_t address, uint32_t data)
 		{
 			m_flash_mode = FM_ERASEAMD3;
 		}
-		else if( ( address & m_addrmask ) == 0x2aaa && ( data & 0xff ) == 0x55 && m_addrmask )
+		else if( ( address & m_addrmask ) == ( 0x2aaa & m_addrmask ) && ( data & 0xff ) == 0x55 && m_addrmask )
 		{
 			m_flash_mode = FM_ERASEAMD3;
 		}

--- a/src/devices/machine/intelfsh.h
+++ b/src/devices/machine/intelfsh.h
@@ -278,6 +278,12 @@ public:
 	sst_39vf020_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
+class sst_39vf040_device : public intelfsh8_device
+{
+public:
+	sst_39vf040_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
 class sst_49lf020_device : public intelfsh8_device
 {
 public:
@@ -449,6 +455,7 @@ DECLARE_DEVICE_TYPE(SST_39SF010,             sst_39sf010_device)
 DECLARE_DEVICE_TYPE(SST_39SF020,             sst_39sf020_device)
 DECLARE_DEVICE_TYPE(SST_39SF040,             sst_39sf040_device)
 DECLARE_DEVICE_TYPE(SST_39VF020,             sst_39vf020_device)
+DECLARE_DEVICE_TYPE(SST_39VF040,             sst_39vf040_device)
 DECLARE_DEVICE_TYPE(SST_49LF020,             sst_49lf020_device)
 
 DECLARE_DEVICE_TYPE(SHARP_LH28F400,          sharp_lh28f400_device)

--- a/src/mame/foenixretro/f256.cpp
+++ b/src/mame/foenixretro/f256.cpp
@@ -25,7 +25,7 @@ f256k_state::f256k_state(const machine_config &mconfig, device_type type, const 
     , m_maincpu(*this, MAINCPU_TAG)
     , m_ram(*this, RAM_TAG)
     , m_iopage(*this, IOPAGE_TAG "%u", 0U)
-    , m_rom(*this, ROM_TAG)
+    , m_flash(*this, FLASH_TAG)
     , m_font(*this, FONT_TAG)
     , m_screen(*this, SCREEN_TAG)
     , m_rtc(*this, "rtc")
@@ -61,6 +61,8 @@ void f256k_state::f256k(machine_config &config)
     {
         RAM(config, iopage).set_default_size("8k").set_default_value(0x0);
     }
+
+    SST_39VF040(config, m_flash);
 
     SCREEN(config, m_screen, SCREEN_TYPE_RASTER);
     m_screen->set_refresh_hz(60); // Refresh rate (e.g., 60Hz)
@@ -631,8 +633,8 @@ u8   f256k_state::mem_r(offs_t offset)
     }
     else if (bank < 0x80)
     {
-        offs_t address = (bank << 13) + low_addr;
-        return m_rom->as_u8(address);
+        offs_t address = ((bank - 0x40) << 13) + low_addr;
+        return m_flash->read_raw(address);
     }
     else if (bank < 0xa0)
     {
@@ -1228,6 +1230,11 @@ void f256k_state::mem_w(offs_t offset, u8 data)
             offs_t address = (bank << 13) + low_addr;
             m_ram->write(address, data);
         }
+    }
+    else if (bank < 0x80)
+    {
+        offs_t address = ((bank - 0x40) << 13) + low_addr;
+        m_flash->write(address, data);
     }
 }
 void f256k_state::codec_done(s32 param)
@@ -1983,10 +1990,10 @@ static INPUT_PORTS_START(f256k)
 INPUT_PORTS_END
 
 ROM_START(f256k)
-    ROM_REGION(0x10'0000,ROM_TAG,0)
+    ROM_REGION(0x80000, FLASH_TAG, ROMREGION_ERASEFF)
 
     #define ROM_BLOCK(offset, filename, size, crc, sha1) \
-        ROM_LOAD(filename, 0x80000 + (offset * 0x2000), size, crc sha1)
+        ROM_LOAD(filename, (offset * 0x2000), size, crc sha1)
 
     F256K_ROM_TABLE(ROM_BLOCK)
     #undef ROM_BLOCK

--- a/src/mame/foenixretro/f256.h
+++ b/src/mame/foenixretro/f256.h
@@ -19,6 +19,7 @@
 #include "machine/6522via.h"
 #include "machine/bq4847.h"
 #include "machine/ins8250.h"
+#include "machine/intelfsh.h"
 #include "machine/ram.h"
 #include "machine/spi_sdcard.h"
 #include "sound/sn76496.h"
@@ -57,7 +58,7 @@ private:
     required_device<cpu_device> m_maincpu;
 	required_device<ram_device> m_ram;
 	required_device_array<ram_device, 4> m_iopage;
-	required_memory_region m_rom;
+	required_device<sst_39vf040_device> m_flash;
 	required_memory_region m_font;
 	required_device<screen_device> m_screen;
 	required_device<bq4802_device> m_rtc;


### PR DESCRIPTION
## Summary
- Replace the static ROM region with an SST 39VF040 flash device so flash contents persist across sessions via NVRAM
- The intelfsh framework handles the SST command protocol (sector erase, byte program); an address mask of 0x1FFF is used so commands are recognized through the F256K's 8KB MMU banking
- Fix an intelfsh FM_ERASEAMD2 inconsistency where the address mask was not applied to both sides of the 0x2AAA comparison